### PR TITLE
Simple but effective

### DIFF
--- a/vmux
+++ b/vmux
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 # vmux
 #  Vim/Neovim sessions with the help of tmux


### PR DESCRIPTION
prevent `File "./vmux", line 73
    self._vmux.session.upper(), *args])
                                   ^
SyntaxError: can use starred expression only as assignment target`
error when using older python
