### PR TITLE
Stop looking for session if positive match is found

### DIFF
--- a/vmux
+++ b/vmux
@@ -433,6 +433,7 @@ def main():
                         'Found editor with session: %s (%s)' % (e, v.session),
                         file=sys.stderr)
                 editor_with_session = e
+                break
 
     # clean up session if it doesn't exist
     if v.session_exists and not editor_with_session:


### PR DESCRIPTION
Fixes selecting the session pane (at least on my setup)

```
$ VMUX_DEBUG=1 vmux foo.txt
Found editor with session: nvim (%64)
Traceback (most recent call last):
  File "/Users/josh/.local/bin/vmux", line 108, in session_exists
    '--serverlist'], stderr=subprocess.PIPE).decode('utf-8').strip().split(os.linesep):
  File "/usr/local/Cellar/python/3.7.1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 389, in check_output
    **kwargs).stdout
  File "/usr/local/Cellar/python/3.7.1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 481, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/vim', '--serverlist']' returned non-zero exit status 1.
Found editor with session: nvim-qt (%64)
```