### PR TITLE
Migrate to pynvim package

### DIFF
--- a/vmux
+++ b/vmux
@@ -209,7 +209,7 @@ class Neovim(Editor):
 
             filenames += [os.path.abspath(os.path.expandvars(os.path.expanduser(item)))]
 
-        from neovim import attach
+        from pynvim import attach
         nvim = attach('socket', path=self.session_address)
 
         # get back to normal mode


### PR DESCRIPTION
`neovim` package is a meta-package that simply loads `pynvim`
so migrate to using `pynvim` directly